### PR TITLE
fix download site url

### DIFF
--- a/devices/hlds-lidar/README.md
+++ b/devices/hlds-lidar/README.md
@@ -48,7 +48,7 @@ AmazonMQなどフルマネージドのものやMosquitoで自分で構築する�
     ※ インストーラ実行時にエラーが発生した場合は同封されているマニュアルで対応方法を確認する
     ``HldsTofSdk.2.3.0vs2015\manual``
 1. 動線計測パッケージのダウンロード
-    1.  [ダウンロードページ](https://hlds.co.jp/product/tofsdk/peopletrack)より、最新版をダウンロードする（例: PeopleTracking_v200.zip）
+    1.  [ダウンロードページ](https://hlds.co.jp/product/tofsdk/PeopleTrack)より、最新版をダウンロードする（例: PeopleTracking_v200.zip）
     1. 任意の場所でzipファイルを展開する
 
 <br/>


### PR DESCRIPTION
## Why do you change the current implementation?
動線計測パッケージダウンロードURLの変更

## What point do you change?
元のurl( "https://hlds.co.jp/product/tofsdk/peopletrack" ) にアクセスすると別のページ( https://solutions.hitachi-lg.biz/hl-dp )にリダイレクトされてしまう。
`peopletrack` -> `PeopleTrack` とすると正しくダウンロードサイトに遷移できる。

英語サイトは変更の必要なし。

## Do you have any special request/focus for this PR?

